### PR TITLE
Use blosum80 supplied with the nanocorrect

### DIFF
--- a/nanocorrect.py
+++ b/nanocorrect.py
@@ -146,7 +146,9 @@ def run_poa_and_consensus(overlaps, read_idx):
     (in_fn, n_reads) = write_poa_input(overlaps, read_idx)
     out_fn = "clustal-%d.out" % (read_idx)
     DEVNULL = open(os.devnull, 'wb')
-    cmd = "poa -read_fasta %s -clustal %s -hb poa-blosum80.mat" % (in_fn, out_fn)
+    # use blosum file relative to the 'nanocorrect.py'
+    blosum_file = os.path.join(os.path.dirname(__file__), "poa-blosum80.mat")
+    cmd = "poa -read_fasta %s -clustal %s -hb %s" % (in_fn, out_fn, blosum_file)
     p = subprocess.Popen(cmd, shell=True, stderr=DEVNULL)
     p.wait()
     consensus =  clustal2consensus(out_fn)

--- a/nanocorrect.py
+++ b/nanocorrect.py
@@ -146,8 +146,12 @@ def run_poa_and_consensus(overlaps, read_idx):
     (in_fn, n_reads) = write_poa_input(overlaps, read_idx)
     out_fn = "clustal-%d.out" % (read_idx)
     DEVNULL = open(os.devnull, 'wb')
-    # use blosum file relative to the 'nanocorrect.py'
-    blosum_file = os.path.join(os.path.dirname(__file__), "poa-blosum80.mat")
+    
+    blosum_file = "poa-blosum80.mat"
+    if not os.path.exists(blosum_file):
+        # use blosum file relative to the 'nanocorrect.py' when local not available.
+        blosum_file = os.path.join(os.path.dirname(__file__), blosum_file)
+        
     cmd = "poa -read_fasta %s -clustal %s -hb %s" % (in_fn, out_fn, blosum_file)
     p = subprocess.Popen(cmd, shell=True, stderr=DEVNULL)
     p.wait()


### PR DESCRIPTION
Currently the BLOSUM80 file is expected to be in the current working directory. However, when analysis is done from different directory it's missing and poa fails. The error is gobbled up by DEVNULL. Instead, workout a path of the nanocorrect.py file and use blosum80 file found in that directory.
