### PR TITLE
Add .DELETE_ON_ERROR

### DIFF
--- a/nanocorrect-overlap.make
+++ b/nanocorrect-overlap.make
@@ -4,6 +4,9 @@ SHELL=/bin/bash -o pipefail
 # A pipeline to run daligner on a set of reads
 #
 
+# do not leave failed files around
+.DELETE_ON_ERROR:
+
 # Our target is the local alignments file that daligner generates
 all: $(NAME).las
 


### PR DESCRIPTION
After continuing after a failed run, I got the error:

```
+ make -f full-pipeline.make CORES=12 polished_genome.fasta
make -f nanocorrect/nanocorrect-overlap.make INPUT=raw.reads.fasta NAME=raw.reads
make[1]: Entering directory '/projects/btl/sjackman/nanopore-paper-analysis'
fasta2DB raw.reads raw.reads.pp.fasta
Skipping 'raw.reads.pp', file is empty!
```
