### PR TITLE
Use #!/usr/bin/env perl to search the PATH

### DIFF
--- a/nanocorrect-preprocess.pl
+++ b/nanocorrect-preprocess.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 #
 # Fake pacbio read names
 #


### PR DESCRIPTION
The perl executable found in the PATH should be used rather than `/usr/bin/perl`.
