### PR TITLE
Add an Alias Script for `nanocorrect-overlap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Example:
 
 First, build the DALIGNER database and compute alignments:
 
-```make -f nanocorrect-overlap.make INPUT=reads.fasta NAME=nc```
+```./nanocorrect-overlap INPUT=reads.fasta NAME=nc```
 
 INPUT is the path to your reads. 
 The NAME variable is the prefix you want to use for the output files.

--- a/nanocorrect-overlap
+++ b/nanocorrect-overlap
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd -P "$( dirname "$SOURCE" )" && pwd )" 
+make -f $DIR/nanocorrect-overlap.make $@


### PR DESCRIPTION
Directly running makefile is actually confusing, so I've created an alias to avoid such kind of confusions.
